### PR TITLE
feat: use expense-specific API path

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ router.options('*', (request) => {
 router.get('*', async (request, env, context) => {
     // Skip asset handling for API routes
     const url = new URL(request.url);
-    if (url.pathname.startsWith('/api')) {
+    if (url.pathname.startsWith('/api/expense')) {
         return undefined;
     }
 
@@ -63,7 +63,7 @@ router.get('*', async (request, env, context) => {
 });
 
 // Handle GET requests
-router.get('/api', async (request, env) => {
+router.get('/api/expense', async (request, env) => {
     const origin = request.headers.get('Origin');
     const corsHeaders = getCorsHeaders(origin);
     try {
@@ -92,7 +92,7 @@ router.get('/api', async (request, env) => {
 });
 
 // Handle POST requests
-router.post('/api', async (request, env) => {
+router.post('/api/expense', async (request, env) => {
     const origin = request.headers.get('Origin');
     const corsHeaders = getCorsHeaders(origin);
     try {
@@ -120,7 +120,7 @@ router.post('/api', async (request, env) => {
 });
 
 // Handle PUT requests
-router.put('/api', async (request, env) => {
+router.put('/api/expense', async (request, env) => {
     const origin = request.headers.get('Origin');
     const corsHeaders = getCorsHeaders(origin);
     try {
@@ -148,7 +148,7 @@ router.put('/api', async (request, env) => {
 });
 
 // Handle DELETE requests
-router.delete('/api', async (request, env) => {
+router.delete('/api/expense', async (request, env) => {
     const origin = request.headers.get('Origin');
     const corsHeaders = getCorsHeaders(origin);
     try {

--- a/index.test.js
+++ b/index.test.js
@@ -33,7 +33,7 @@ const createMockRequest = (url, method = 'GET', headers = {}, body = null) => {
     return request;
 };
 
-describe('GET /api', () => {
+describe('GET /api/expense', () => {
     beforeEach(() => {
         // Reset mocks before each test
         vi.clearAllMocks();
@@ -54,7 +54,7 @@ describe('GET /api', () => {
         ];
         mockAll.mockResolvedValueOnce({ results: mockExpenses });
 
-        const request = createMockRequest('http://localhost/api?year=2023&month=01', 'GET', { 'Origin': 'https://expensetracker.hgnlab.org' });
+        const request = createMockRequest('http://localhost/api/expense?year=2023&month=01', 'GET', { 'Origin': 'https://expensetracker.hgnlab.org' });
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(200);
@@ -67,7 +67,7 @@ describe('GET /api', () => {
 
     it('should return an empty array if no expenses are found', async () => {
         // Default mockAll already returns empty results
-        const request = createMockRequest('http://localhost/api?year=2024&month=07', 'GET', { 'Origin': 'http://localhost:8787' });
+        const request = createMockRequest('http://localhost/api/expense?year=2024&month=07', 'GET', { 'Origin': 'http://localhost:8787' });
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(200);
@@ -77,7 +77,7 @@ describe('GET /api', () => {
     });
 
     it('should return 400 if year is missing', async () => {
-        const request = createMockRequest('http://localhost/api?month=01', 'GET', { 'Origin': 'https://expensetracker.hgnlab.org' });
+        const request = createMockRequest('http://localhost/api/expense?month=01', 'GET', { 'Origin': 'https://expensetracker.hgnlab.org' });
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(400);
@@ -85,7 +85,7 @@ describe('GET /api', () => {
     });
 
     it('should return 400 if month is missing', async () => {
-        const request = createMockRequest('http://localhost/api?year=2023', 'GET', { 'Origin': 'https://expensetracker.hgnlab.org' });
+        const request = createMockRequest('http://localhost/api/expense?year=2023', 'GET', { 'Origin': 'https://expensetracker.hgnlab.org' });
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(400);
@@ -96,7 +96,7 @@ describe('GET /api', () => {
         const errorMessage = 'Database connection error';
         mockAll.mockRejectedValueOnce(new Error(errorMessage));
 
-        const request = createMockRequest('http://localhost/api?year=2023&month=01', 'GET', { 'Origin': 'https://expensetracker.hgnlab.org' });
+        const request = createMockRequest('http://localhost/api/expense?year=2023&month=01', 'GET', { 'Origin': 'https://expensetracker.hgnlab.org' });
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(500);
@@ -105,7 +105,7 @@ describe('GET /api', () => {
 
     describe('CORS Preflight (OPTIONS) requests', () => {
         it('should return 204 with correct CORS headers for allowed origin', async () => {
-            const request = createMockRequest('http://localhost/api', 'OPTIONS', {
+            const request = createMockRequest('http://localhost/api/expense', 'OPTIONS', {
                 'Origin': 'https://expensetracker.hgnlab.org',
                 'Access-Control-Request-Method': 'GET',
                 'Access-Control-Request-Headers': 'Content-Type',
@@ -119,7 +119,7 @@ describe('GET /api', () => {
         });
 
         it('should return 204 with Access-Control-Allow-Origin: null for disallowed origin', async () => {
-            const request = createMockRequest('http://localhost/api', 'OPTIONS', {
+            const request = createMockRequest('http://localhost/api/expense', 'OPTIONS', {
                 'Origin': 'https://malicious.com',
                 'Access-Control-Request-Method': 'GET',
                 'Access-Control-Request-Headers': 'Content-Type',
@@ -158,7 +158,7 @@ describe('Static Asset Serving', () => {
     });
 });
 
-describe('POST /api', () => {
+describe('POST /api/expense', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockRun.mockResolvedValue({ success: true });
@@ -173,7 +173,7 @@ describe('POST /api', () => {
             description: 'New Book',
             category: 'Education',
         };
-        const request = createMockRequest('http://localhost/api', 'POST', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, newExpense);
+        const request = createMockRequest('http://localhost/api/expense', 'POST', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, newExpense);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(201);
@@ -190,7 +190,7 @@ describe('POST /api', () => {
             description: 'New Book',
             // category is missing
         };
-        const request = createMockRequest('http://localhost/api', 'POST', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, incompleteExpense);
+        const request = createMockRequest('http://localhost/api/expense', 'POST', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, incompleteExpense);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(400);
@@ -204,7 +204,7 @@ describe('POST /api', () => {
             description: 'New Book',
             category: 'Education',
         };
-        const request = createMockRequest('http://localhost/api', 'POST', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, invalidExpense);
+        const request = createMockRequest('http://localhost/api/expense', 'POST', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, invalidExpense);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(400);
@@ -221,7 +221,7 @@ describe('POST /api', () => {
             description: 'New Book',
             category: 'Education',
         };
-        const request = createMockRequest('http://localhost/api', 'POST', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, newExpense);
+        const request = createMockRequest('http://localhost/api/expense', 'POST', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, newExpense);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(500);
@@ -229,7 +229,7 @@ describe('POST /api', () => {
     });
 });
 
-describe('PUT /api', () => {
+describe('PUT /api/expense', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockRun.mockResolvedValue({ success: true });
@@ -245,7 +245,7 @@ describe('PUT /api', () => {
             description: 'Updated Book',
             category: 'Education',
         };
-        const request = createMockRequest('http://localhost/api', 'PUT', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, updatedExpense);
+        const request = createMockRequest('http://localhost/api/expense', 'PUT', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, updatedExpense);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(200);
@@ -263,7 +263,7 @@ describe('PUT /api', () => {
             // description is missing
             category: 'Education',
         };
-        const request = createMockRequest('http://localhost/api', 'PUT', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, incompleteUpdate);
+        const request = createMockRequest('http://localhost/api/expense', 'PUT', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, incompleteUpdate);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(400);
@@ -278,7 +278,7 @@ describe('PUT /api', () => {
             description: 'Updated Book',
             category: 'Education',
         };
-        const request = createMockRequest('http://localhost/api', 'PUT', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, invalidUpdate);
+        const request = createMockRequest('http://localhost/api/expense', 'PUT', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, invalidUpdate);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(400);
@@ -296,7 +296,7 @@ describe('PUT /api', () => {
             description: 'Updated Book',
             category: 'Education',
         };
-        const request = createMockRequest('http://localhost/api', 'PUT', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, updatedExpense);
+        const request = createMockRequest('http://localhost/api/expense', 'PUT', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, updatedExpense);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(500);
@@ -304,7 +304,7 @@ describe('PUT /api', () => {
     });
 });
 
-describe('DELETE /api', () => {
+describe('DELETE /api/expense', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockRun.mockResolvedValue({ success: true });
@@ -316,7 +316,7 @@ describe('DELETE /api', () => {
         const expenseToDelete = { id: 1 };
         mockRun.mockResolvedValueOnce({ success: true }); // Explicitly mock for this test
 
-        const request = createMockRequest('http://localhost/api', 'DELETE', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, expenseToDelete);
+        const request = createMockRequest('http://localhost/api/expense', 'DELETE', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, expenseToDelete);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(200);
@@ -328,7 +328,7 @@ describe('DELETE /api', () => {
 
     it('should return 400 if id is missing', async () => {
         const incompleteDelete = { /* id is missing */ };
-        const request = createMockRequest('http://localhost/api', 'DELETE', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, incompleteDelete);
+        const request = createMockRequest('http://localhost/api/expense', 'DELETE', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, incompleteDelete);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(400);
@@ -339,7 +339,7 @@ describe('DELETE /api', () => {
         const expenseToDelete = { id: 999 }; // Non-existent ID
         mockRun.mockResolvedValueOnce({ success: false }); // Simulate no rows affected
 
-        const request = createMockRequest('http://localhost/api', 'DELETE', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, expenseToDelete);
+        const request = createMockRequest('http://localhost/api/expense', 'DELETE', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, expenseToDelete);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(404);
@@ -351,7 +351,7 @@ describe('DELETE /api', () => {
         mockRun.mockRejectedValueOnce(new Error(errorMessage));
 
         const expenseToDelete = { id: 1 };
-        const request = createMockRequest('http://localhost/api', 'DELETE', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, expenseToDelete);
+        const request = createMockRequest('http://localhost/api/expense', 'DELETE', { 'Origin': 'https://expensetracker.hgnlab.org', 'Content-Type': 'application/json' }, expenseToDelete);
         const response = await worker.fetch(request, mockEnv);
 
         expect(response.status).toBe(500);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,7 +7,7 @@ servers:
   - url: mony-worker.hgnguyen37.workers.dev
     description: Production server
 paths:
-  /api/expenses:
+  /api/expense:
     get:
       summary: Get expenses for a specific month and year
       description: Fetches a list of all expenses recorded for a given month and year.

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -4,7 +4,7 @@
   "exclude": [],
   "routes": [
     {
-      "route": "/api",
+      "route": "/api/expense",
       "function": "/cf-mony-worker/index.js"
     }
   ]

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -1,4 +1,4 @@
-const apiUrl = '/api';
+const apiUrl = '/api/expense';
 const monthlyBudget = {
     'Food': 5000000,
     'Medical/Utility': 2000000,

--- a/public/scripts.test.js
+++ b/public/scripts.test.js
@@ -221,10 +221,10 @@ describe('scripts.js (Vitest + jsdom, high coverage)', () => {
       initialGet: { ok: true, json: async () => SAMPLE_EXPENSES },
     });
 
-    // Initial GET called once with /api?year=YYYY&month=MM (based on mocked date 2025-08-09)
+    // Initial GET called once with /api/expense?year=YYYY&month=MM (based on mocked date 2025-08-09)
     expect(fetchMock).toHaveBeenCalledTimes(1); // Corrected: scripts.js calls fetchExpensesForMonth() only inside DOMContentLoaded
     const firstUrl = fetchMock.mock.calls[0][0];
-    expect(firstUrl).toMatch(/^\/api\?year=2025&month=08$/);
+    expect(firstUrl).toMatch(/^\/api\/expense\?year=2025&month=08$/);
 
     // Date input & month picker set
     const dateInput = document.getElementById('date');
@@ -386,7 +386,7 @@ describe('scripts.js (Vitest + jsdom, high coverage)', () => {
 
     // Mock POST then GET refresh
     fetchMock
-      .mockResolvedValueOnce({ ok: true, json: async () => ({}) }) // POST /api
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) }) // POST /api/expense
       .mockResolvedValueOnce({ ok: true, json: async () => SAMPLE_EXPENSES }); // GET refresh
 
     const date = document.getElementById('date');
@@ -421,7 +421,7 @@ describe('scripts.js (Vitest + jsdom, high coverage)', () => {
     expect(postBody.amount).toBe(1234567);
 
     // After POST ok, a GET refresh is issued
-    expect(fetchMock.mock.calls.some(c => typeof c[0] === 'string' && c[0].startsWith('/api?year='))).toBe(true);
+    expect(fetchMock.mock.calls.some(c => typeof c[0] === 'string' && c[0].startsWith('/api/expense?year='))).toBe(true);
 
     // Form date reset back to "today" (2025-08-09 in our mocked clock)
     expect(document.getElementById('date').value).toBe('2025-08-09');
@@ -567,7 +567,7 @@ describe('scripts.js (Vitest + jsdom, high coverage)', () => {
 
     // Second GET has month=07
     const lastUrl = fetchMock.mock.calls[fetchMock.mock.calls.length - 1][0];
-    expect(lastUrl).toMatch('/api?year=2025&month=07');
+    expect(lastUrl).toMatch('/api/expense?year=2025&month=07');
 
     // Chart called twice and first instance destroyed on second render
     expect(chartFactory).toHaveBeenCalledTimes(2); // Corrected: 1 initial call + 1 on month change

--- a/static-assets.test.js
+++ b/static-assets.test.js
@@ -33,8 +33,8 @@ describe('static asset handling', () => {
     expect(call[0].waitUntil).toBe(context.waitUntil);
   });
 
-  it('ignores /api routes when serving assets', async () => {
-    const request = new Request('http://localhost/api?year=2023&month=01');
+  it('ignores /api/expense routes when serving assets', async () => {
+    const request = new Request('http://localhost/api/expense?year=2023&month=01');
     const env = {
       __STATIC_CONTENT: {},
       __STATIC_CONTENT_MANIFEST: {},


### PR DESCRIPTION
## Summary
- expose CRUD routes under `/api/expense`
- adjust front-end and Cloudflare routing for new path
- update OpenAPI spec and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689785f25604832abfb6034d66f8d260