### PR TITLE
fix: improve mobile charts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -70,10 +70,10 @@
         </div>
 
         <div class="d-flex justify-content-center my-4 gap-4 flex-wrap">
-            <div class="chart-container" style="position: relative; height:40vh; width:40vw;">
+            <div class="chart-container">
                 <canvas id="expense-chart"></canvas>
             </div>
-            <div class="chart-container" style="position: relative; height:40vh; width:40vw;">
+            <div class="chart-container">
                 <canvas id="burndown-chart"></canvas>
             </div>
         </div>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -138,10 +138,18 @@ export function createExpenseTrackerApp(domElements) {
         });
 
         const actual = [];
+        const currentYear = String(today.getFullYear());
+        const currentMonth = String(today.getMonth() + 1).padStart(2, '0');
+        const currentDay = today.getDate();
+        const isCurrentMonth = year === currentYear && month === currentMonth;
         let running = 0;
         for (let i = 0; i < daysInMonth; i++) {
             running += dailyTotals[i];
-            actual.push(running);
+            if (isCurrentMonth && i >= currentDay) {
+                actual.push(null);
+            } else {
+                actual.push(running);
+            }
         }
 
         const expected = [];

--- a/public/scripts.test.js
+++ b/public/scripts.test.js
@@ -298,6 +298,9 @@ describe('scripts.js (Vitest + jsdom, high coverage)', () => {
     });
     const burnArgs = chartFactory.mock.calls[1];
     expect(burnArgs[1]).toMatchObject({ type: 'line' });
+    const actualData = burnArgs[1].data.datasets[0].data;
+    expect(actualData[8]).toBeGreaterThan(0); // day 9 has spending
+    expect(actualData[9]).toBeNull(); // day 10 not yet occurred
 
     cleanup();
   });

--- a/public/styles.css
+++ b/public/styles.css
@@ -69,3 +69,16 @@
     border-color: #d39e00;
 }
 
+/* Responsive chart containers prioritize mobile view */
+.chart-container {
+    position: relative;
+    width: 100%;
+    height: 40vh;
+}
+
+@media (min-width: 768px) {
+    .chart-container {
+        width: 45%;
+    }
+}
+


### PR DESCRIPTION
## Summary
- make charts responsive for mobile-first layout
- stop burndown chart actual line at today's date
- update tests for new burndown behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a0b743f18832ab780f295d6eea3ce