### PR TITLE
Allow negative amounts in UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="amount" class="form-label">Amount (in ₫)</label>
-                            <input type="text" inputmode="numeric" class="form-control" id="amount" placeholder="Enter amount" required>
+                            <input type="text" inputmode="decimal" class="form-control" id="amount" placeholder="Enter amount" required>
                         </div>
                     </div>
                     <div class="mb-3">
@@ -147,7 +147,7 @@
                         </div>
                         <div class="mb-3">
                             <label for="modify-amount" class="form-label">Amount (in ₫)</label>
-                            <input type="text" inputmode="numeric" class="form-control" id="modify-amount" required>
+                            <input type="text" inputmode="decimal" class="form-control" id="modify-amount" required>
                         </div>
                         <div class="mb-3">
                             <label for="modify-description" class="form-label">Description</label>
@@ -190,7 +190,7 @@
                 </div>
                 <div class="mb-3 px-3">
                     <label for="delete-amount-input" class="form-label">To confirm, please enter the exact amount of the expense:</label>
-                    <input type="text" inputmode="numeric" class="form-control" id="delete-amount-input" placeholder="e.g., 30.000">
+                    <input type="text" inputmode="decimal" class="form-control" id="delete-amount-input" placeholder="e.g., 30.000">
                     <div id="delete-warning" class="text-danger mt-2" style="display: none;">The amount entered is incorrect.</div>
                 </div>
                 <div class="modal-footer">

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -25,7 +25,13 @@ const startOfMonthCategories = ['Home', 'Baby'];
 export function createExpenseTrackerApp(domElements) {
     // Moved inside to ensure correct scope
     function formatNumber(value) {
-        return value.replace(/\D/g, "").replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+        const isNegative = value.startsWith('-');
+        const digits = value.replace(/\D/g, '');
+        const formattedDigits = digits.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+        if (isNegative) {
+            return digits ? `-${formattedDigits}` : '-';
+        }
+        return formattedDigits;
     }
 
     // Moved inside to ensure correct scope
@@ -60,16 +66,18 @@ export function createExpenseTrackerApp(domElements) {
     });
 
     function checkFormValidity() {
-        const fields = [dateInput, amountInput, descriptionInput, categoryInput];
-        const allFieldsFilled = fields.every(field => field.value.trim() !== '');
+        const amountValue = amountInput.value.replace(/\./g, '');
+        const isAmountValid = amountValue !== '' && amountValue !== '-';
+        const otherFields = [dateInput, descriptionInput, categoryInput];
+        const allFieldsFilled = otherFields.every(field => field.value.trim() !== '') && isAmountValid;
         addExpenseBtn.disabled = !allFieldsFilled;
     }
 
     function validateAndHighlight() {
-        const fields = [dateInput, amountInput, descriptionInput, categoryInput];
+        const otherFields = [dateInput, descriptionInput, categoryInput];
         let allValid = true;
 
-        fields.forEach(field => {
+        otherFields.forEach(field => {
             if (!field.value.trim()) {
                 allValid = false;
                 field.classList.add('is-invalid');
@@ -77,6 +85,14 @@ export function createExpenseTrackerApp(domElements) {
                 field.classList.remove('is-invalid');
             }
         });
+
+        const amountValue = amountInput.value.replace(/\./g, '');
+        if (amountValue === '' || amountValue === '-') {
+            allValid = false;
+            amountInput.classList.add('is-invalid');
+        } else {
+            amountInput.classList.remove('is-invalid');
+        }
 
         return allValid;
     }
@@ -575,7 +591,12 @@ export function createExpenseTrackerApp(domElements) {
     [dateInput, amountInput, descriptionInput, categoryInput].forEach(input => {
         input.addEventListener('input', () => {
             checkFormValidity();
-            if (input.value.trim() !== '') {
+            if (input === amountInput) {
+                const val = amountInput.value.replace(/\./g, '');
+                if (val !== '' && val !== '-') {
+                    amountInput.classList.remove('is-invalid');
+                }
+            } else if (input.value.trim() !== '') {
                 input.classList.remove('is-invalid');
             }
         });

--- a/public/scripts.test.js
+++ b/public/scripts.test.js
@@ -347,6 +347,10 @@ describe('scripts.js (Vitest + jsdom, high coverage)', () => {
     amount.dispatchEvent(new document.defaultView.Event('input', { bubbles: true }));
     expect(amount.value).toBe('1.234.567');
 
+    amount.value = '-1234';
+    amount.dispatchEvent(new document.defaultView.Event('input', { bubbles: true }));
+    expect(amount.value).toBe('-1.234');
+
     cleanup();
   });
 

--- a/public/scripts.test.js
+++ b/public/scripts.test.js
@@ -390,6 +390,36 @@ describe('scripts.js (Vitest + jsdom, high coverage)', () => {
     cleanup();
   });
 
+  it('marks amount invalid when empty or only a minus sign', async () => {
+    const { document, app, cleanup } = await bootApp({
+      initialGet: { ok: true, json: async () => [] },
+    });
+
+    const date = document.getElementById('date');
+    const amount = document.getElementById('amount');
+    const desc = document.getElementById('description');
+    const cat = document.getElementById('category');
+
+    date.value = '2025-08-09';
+    desc.value = 'Test';
+    cat.value = 'Food';
+
+    // Empty amount
+    amount.value = '';
+    let valid = app.validateAndHighlight();
+    expect(valid).toBe(false);
+    expect(amount.classList.contains('is-invalid')).toBe(true);
+
+    // Just a minus sign
+    amount.classList.remove('is-invalid');
+    amount.value = '-';
+    valid = app.validateAndHighlight();
+    expect(valid).toBe(false);
+    expect(amount.classList.contains('is-invalid')).toBe(true);
+
+    cleanup();
+  });
+
   it('adds an expense (POST), refreshes list (GET), and resets form date', async () => {
     const { document, fetchMock, cleanup } = await bootApp({
       initialGet: { ok: true, json: async () => [] },


### PR DESCRIPTION
## Summary
- Allow negative values for amount inputs and related fields in the UI
- Preserve leading minus sign during number formatting and validation
- Expand tests to cover negative amount formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc59eefb8832ab27e1c4010e394c2