### PR TITLE
feat: add monthly summary view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: npm install
 
     - name: Run Vitest and collect coverage
-      run: npm test -- --coverage # Assumes your "test" script in package.json runs vitest
+      run: vitest --config vitest.ci.config.js --coverage # Assumes your "test" script in package.json runs vitest
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
       - run: npm install
       - run: npm install --no-save selenium-webdriver
-      - run: npm test
+      - run: npm test ui.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ package-lock.json
 
 # Cloudflare Wrangler build and temporary files
 .wrangler/
+schema-and-data.sql
 
 # macOS specific files
 .DS_Store

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -100,6 +100,42 @@ paths:
         '204':
           description: No content, CORS headers are sent.
 
+  /api/summary:
+    get:
+      summary: Get monthly spending by category
+      description: Returns total spending for each category for a given month.
+      parameters:
+        - name: year
+          in: query
+          required: true
+          description: The year to filter summary by (e.g., 2025).
+          schema:
+            type: string
+        - name: month
+          in: query
+          required: true
+          description: The month to filter summary by (e.g., 07 for July).
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Spending totals by category for the specified period.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    category:
+                      type: string
+                    spend_vnd:
+                      type: number
+        '400':
+          description: Bad request, likely due to missing query parameters.
+        '500':
+          description: Internal server error.
+
 components:
   schemas:
     Expense:

--- a/public/summary.js
+++ b/public/summary.js
@@ -1,0 +1,45 @@
+const apiUrl = '/api/summary';
+
+export function createSummaryApp(dom) {
+    const { monthPicker, chartCanvas, totalDiv } = dom;
+    let chart = null;
+
+    const today = new Date();
+    monthPicker.value = today.toISOString().slice(0, 7);
+
+    async function fetchAndRender() {
+        const [year, month] = monthPicker.value.split('-');
+        const resp = await fetch(`${apiUrl}?year=${year}&month=${month}`);
+        const data = await resp.json();
+        const labels = data.map(d => d.category);
+        const values = data.map(d => d.spend_vnd);
+        const total = values.reduce((sum, v) => sum + v, 0);
+        totalDiv.textContent = `Total: ${total.toLocaleString('vi-VN')} ₫`;
+
+        if (chart) chart.destroy();
+        chart = new Chart(chartCanvas, {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [{
+                    label: 'Spend (VND)',
+                    data: values,
+                    backgroundColor: '#36A2EB',
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false },
+                    title: { display: true, text: 'Spending by Category' }
+                }
+            }
+        });
+    }
+
+    monthPicker.addEventListener('change', fetchAndRender);
+    fetchAndRender();
+
+    return { fetchAndRender };
+}

--- a/public/summary.test.js
+++ b/public/summary.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { createSummaryApp } from './summary.js';
+
+function buildHTML() {
+  return `
+  <input id="month-picker" />
+  <div id="summary-total"></div>
+  <canvas id="summary-chart"></canvas>
+  `;
+}
+
+describe('summary.js', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T00:00:00Z'));
+  });
+
+  it('fetches data and renders chart', async () => {
+    const dom = new JSDOM(buildHTML(), { url: 'http://localhost/' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve([
+        { category: 'Food', spend_vnd: 1000 },
+        { category: 'Home', spend_vnd: 2000 },
+      ])
+    });
+    global.fetch = fetchMock;
+
+    const chartFactory = vi.fn(() => ({ destroy: vi.fn() }));
+    global.Chart = chartFactory;
+
+    const domElements = {
+      monthPicker: document.getElementById('month-picker'),
+      chartCanvas: document.getElementById('summary-chart'),
+      totalDiv: document.getElementById('summary-total'),
+    };
+
+    createSummaryApp(domElements);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/summary?year=2024&month=06');
+    expect(chartFactory).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('summary-total').textContent).toMatch(/3[.,]000/);
+  });
+});

--- a/public/summary/index.html
+++ b/public/summary/index.html
@@ -22,8 +22,25 @@
     </nav>
     <div class="container mt-5">
         <h1 class="mb-4 text-center">Summary</h1>
-        <p class="text-center">Summary content goes here.</p>
+        <div class="d-flex justify-content-center mb-4">
+            <input type="month" id="month-picker" class="form-control" style="max-width:200px;">
+        </div>
+        <div id="summary-total" class="text-center mb-4"></div>
+        <div class="d-flex justify-content-center">
+            <div class="chart-container" style="max-width:600px;width:100%;height:400px;">
+                <canvas id="summary-chart"></canvas>
+            </div>
+        </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script type="module">
+        import { createSummaryApp } from '/summary.js';
+        createSummaryApp({
+            monthPicker: document.getElementById('month-picker'),
+            chartCanvas: document.getElementById('summary-chart'),
+            totalDiv: document.getElementById('summary-total')
+        });
+    </script>
 </body>
 </html>

--- a/static-assets.test.js
+++ b/static-assets.test.js
@@ -39,12 +39,34 @@ describe('static asset handling', () => {
       __STATIC_CONTENT: {},
       __STATIC_CONTENT_MANIFEST: {},
       waitUntil: vi.fn(),
-      D1_DATABASE: { prepare: vi.fn() },
+      D1_DATABASE: {
+        prepare: vi.fn(() => ({
+          bind: () => ({ all: vi.fn().mockResolvedValue({ results: [] }) })
+        }))
+      },
     };
 
     await worker.fetch(request, env);
 
     // getAssetFromKV should not be called for API routes
+    expect(getAssetFromKV).not.toHaveBeenCalled();
+  });
+
+  it('ignores /api/summary routes when serving assets', async () => {
+    const request = new Request('http://localhost/api/summary?year=2023&month=01');
+    const env = {
+      __STATIC_CONTENT: {},
+      __STATIC_CONTENT_MANIFEST: {},
+      waitUntil: vi.fn(),
+      D1_DATABASE: {
+        prepare: vi.fn(() => ({
+          bind: () => ({ all: vi.fn().mockResolvedValue({ results: [] }) })
+        }))
+      },
+    };
+
+    await worker.fetch(request, env);
+
     expect(getAssetFromKV).not.toHaveBeenCalled();
   });
 

--- a/ui.test.js
+++ b/ui.test.js
@@ -1,36 +1,60 @@
-import { describe, it, expect } from 'vitest';
-import { JSDOM } from 'jsdom';
-import fs from 'node:fs';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Builder, By } from 'selenium-webdriver';
+import chrome from 'selenium-webdriver/chrome';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-function loadPage(page) {
-  const file = fs.readFileSync(path.join(__dirname, 'public', page, 'index.html'), 'utf-8');
-  return new JSDOM(file);
+let driver;
+
+async function loadPage(page) {
+  const filePath = path.join(__dirname, 'public', page, 'index.html');
+  const url = pathToFileURL(filePath).href;
+  await driver.get(url);
 }
 
+beforeAll(async () => {
+  const options = new chrome.Options();
+  options.addArguments('--headless', '--no-sandbox', '--disable-dev-shm-usage');
+  driver = await new Builder().forBrowser('chrome').setChromeOptions(options).build();
+});
+
+afterAll(async () => {
+  if (driver) {
+    await driver.quit();
+  }
+});
+
 describe('Expense Tracker UI', () => {
-  it('renders expense page title', () => {
-    const { window } = loadPage('expense');
-    expect(window.document.title).toBe('Expense Tracker');
+  it('renders expense page title', async () => {
+    await loadPage('expense');
+    const title = await driver.getTitle();
+    expect(title).toBe('Expense Tracker');
   });
 
-  it('has navbar links to all pages', () => {
-    const { window } = loadPage('expense');
-    const links = Array.from(window.document.querySelectorAll('nav a'))
-      .map(a => a.getAttribute('href'))
-      .filter(href => href !== '#');
-    expect(links).toEqual(['/expense', '/summary', '/insights']);
+  it('has navbar links to all pages', async () => {
+    await loadPage('expense');
+    const links = await driver.findElements(By.css('nav a[href]'));
+    const hrefs = [];
+    for (const link of links) {
+      const href = await link.getAttribute('href');
+      if (!href.endsWith('#')) {
+        hrefs.push(new URL(href).pathname);
+      }
+    }
+    expect(hrefs).toEqual(['/expense', '/summary', '/insights']);
   });
 
-  it('renders summary placeholder', () => {
-    const { window } = loadPage('summary');
-    const heading = window.document.querySelector('h1');
-    expect(heading.textContent).toMatch(/summary/i);
+  it('renders summary layout', async () => {
+    await loadPage('summary');
+    const heading = await driver.findElement(By.css('h1')).getText();
+    expect(heading.toLowerCase()).toContain('summary');
+    await driver.findElement(By.id('month-picker'));
+    await driver.findElement(By.id('summary-chart'));
   });
 
-  it('renders insights placeholder', () => {
-    const { window } = loadPage('insights');
-    const heading = window.document.querySelector('h1');
-    expect(heading.textContent).toMatch(/insights/i);
+  it('renders insights placeholder', async () => {
+    await loadPage('insights');
+    const heading = await driver.findElement(By.css('h1')).getText();
+    expect(heading.toLowerCase()).toContain('insights');
   });
 });

--- a/vitest.ci.config.js
+++ b/vitest.ci.config.js
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from './vitest.config';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      exclude: ['**/ui.test.js'],
+    },
+  })
+);


### PR DESCRIPTION
## Summary
- add `/api/summary` endpoint backed by `v_monthly_category_spend`
- show monthly spend chart on summary page
- test summary API and UI
- merge latest main and separate UI tests in CI

## Testing
- `npm test` *(fails: Unable to obtain browser driver)*

------
https://chatgpt.com/codex/tasks/task_e_689d6e907e34832abe4f7c325c65283b