### PR TITLE
Add six-month spending trends to summary page

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -73,12 +73,6 @@
 .chart-container {
     position: relative;
     width: 100%;
-    height: 40vh;
-}
-
-@media (min-width: 768px) {
-    .chart-container {
-        width: 45%;
-    }
+    height: 300px;
 }
 

--- a/public/summary.js
+++ b/public/summary.js
@@ -43,8 +43,14 @@ export function createSummaryApp(dom) {
         categoryChartsDiv.innerHTML = '';
 
         dailyCategories.forEach(cat => {
+            const col = document.createElement('div');
+            col.className = 'col-12 col-md-6';
+            const container = document.createElement('div');
+            container.className = 'chart-container';
             const canvas = document.createElement('canvas');
-            categoryChartsDiv.appendChild(canvas);
+            container.appendChild(canvas);
+            col.appendChild(container);
+            categoryChartsDiv.appendChild(col);
             const chart = new Chart(canvas, {
                 type: 'line',
                 data: {

--- a/public/summary.js
+++ b/public/summary.js
@@ -1,30 +1,84 @@
 const apiUrl = '/api/summary';
+const dailyCategories = ['Food', 'Medical/Utility', 'Transportation', 'Entertainment'];
+const categoryColors = {
+    'Food': '#FF6384',
+    'Medical/Utility': '#4BC0C0',
+    'Transportation': '#36A2EB',
+    'Entertainment': '#9966FF',
+};
 
 export function createSummaryApp(dom) {
-    const { monthPicker, chartCanvas, totalDiv } = dom;
-    let chart = null;
-
-    const today = new Date();
-    monthPicker.value = today.toISOString().slice(0, 7);
+    const { categoryChartsDiv, totalCanvas } = dom;
+    let charts = [];
 
     async function fetchAndRender() {
-        const [year, month] = monthPicker.value.split('-');
-        const resp = await fetch(`${apiUrl}?year=${year}&month=${month}`);
-        const data = await resp.json();
-        const labels = data.map(d => d.category);
-        const values = data.map(d => d.spend_vnd);
-        const total = values.reduce((sum, v) => sum + v, 0);
-        totalDiv.textContent = `Total: ${total.toLocaleString('vi-VN')} ₫`;
+        const now = new Date();
+        const months = [];
+        const requests = [];
+        for (let i = 5; i >= 0; i--) {
+            const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+            const year = d.getFullYear();
+            const month = String(d.getMonth() + 1).padStart(2, '0');
+            months.push(`${year}-${month}`);
+            requests.push(fetch(`${apiUrl}?year=${year}&month=${month}`).then(r => r.json()));
+        }
 
-        if (chart) chart.destroy();
-        chart = new Chart(chartCanvas, {
-            type: 'bar',
+        const results = await Promise.all(requests);
+        const dataByCategory = {};
+        dailyCategories.forEach(cat => dataByCategory[cat] = []);
+        const totals = [];
+
+        results.forEach(monthData => {
+            let monthTotal = 0;
+            monthData.forEach(d => { monthTotal += d.spend_vnd; });
+            totals.push(monthTotal);
+            dailyCategories.forEach(cat => {
+                const entry = monthData.find(d => d.category === cat);
+                dataByCategory[cat].push(entry ? entry.spend_vnd : 0);
+            });
+        });
+
+        charts.forEach(c => c.destroy());
+        charts = [];
+        categoryChartsDiv.innerHTML = '';
+
+        dailyCategories.forEach(cat => {
+            const canvas = document.createElement('canvas');
+            categoryChartsDiv.appendChild(canvas);
+            const chart = new Chart(canvas, {
+                type: 'line',
+                data: {
+                    labels: months,
+                    datasets: [{
+                        label: cat,
+                        data: dataByCategory[cat],
+                        borderColor: categoryColors[cat],
+                        backgroundColor: categoryColors[cat],
+                        fill: false,
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { display: false },
+                        title: { display: true, text: `${cat} Spending` },
+                    }
+                }
+            });
+            charts.push(chart);
+        });
+
+        const totalChart = new Chart(totalCanvas, {
+            type: 'line',
             data: {
-                labels,
+                labels: months,
                 datasets: [{
-                    label: 'Spend (VND)',
-                    data: values,
-                    backgroundColor: '#36A2EB',
+                    label: 'Total',
+                    data: totals,
+                    borderColor: '#FFCE56',
+                    backgroundColor: '#FFCE56',
+                    fill: false,
                 }]
             },
             options: {
@@ -32,14 +86,12 @@ export function createSummaryApp(dom) {
                 maintainAspectRatio: false,
                 plugins: {
                     legend: { display: false },
-                    title: { display: true, text: 'Spending by Category' }
+                    title: { display: true, text: 'Total Spending' },
                 }
             }
         });
+        charts.push(totalChart);
     }
-
-    monthPicker.addEventListener('change', fetchAndRender);
-    fetchAndRender();
 
     return { fetchAndRender };
 }

--- a/public/summary.js
+++ b/public/summary.js
@@ -15,7 +15,7 @@ export function createSummaryApp(dom) {
         const now = new Date();
         const months = [];
         const requests = [];
-        for (let i = 5; i >= 0; i--) {
+        for (let i = 6; i >= 1; i--) {
             const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
             const year = d.getFullYear();
             const month = String(d.getMonth() + 1).padStart(2, '0');

--- a/public/summary.test.js
+++ b/public/summary.test.js
@@ -4,9 +4,8 @@ import { createSummaryApp } from './summary.js';
 
 function buildHTML() {
   return `
-  <input id="month-picker" />
-  <div id="summary-total"></div>
-  <canvas id="summary-chart"></canvas>
+  <div id="category-charts"></div>
+  <canvas id="total-chart"></canvas>
   `;
 }
 
@@ -16,34 +15,43 @@ describe('summary.js', () => {
     vi.setSystemTime(new Date('2024-06-15T00:00:00Z'));
   });
 
-  it('fetches data and renders chart', async () => {
+  it('fetches last 6 months and renders charts', async () => {
     const dom = new JSDOM(buildHTML(), { url: 'http://localhost/' });
     global.window = dom.window;
     global.document = dom.window.document;
 
     const fetchMock = vi.fn().mockResolvedValue({
       json: () => Promise.resolve([
-        { category: 'Food', spend_vnd: 1000 },
-        { category: 'Home', spend_vnd: 2000 },
+        { category: 'Food', spend_vnd: 100 },
+        { category: 'Medical/Utility', spend_vnd: 200 },
+        { category: 'Transportation', spend_vnd: 300 },
+        { category: 'Entertainment', spend_vnd: 400 },
       ])
     });
     global.fetch = fetchMock;
 
-    const chartFactory = vi.fn(() => ({ destroy: vi.fn() }));
+    const chartFactory = vi.fn(() => ({}));
     global.Chart = chartFactory;
 
     const domElements = {
-      monthPicker: document.getElementById('month-picker'),
-      chartCanvas: document.getElementById('summary-chart'),
-      totalDiv: document.getElementById('summary-total'),
+      categoryChartsDiv: document.getElementById('category-charts'),
+      totalCanvas: document.getElementById('total-chart'),
     };
 
-    createSummaryApp(domElements);
-    await Promise.resolve();
-    await Promise.resolve();
+    const app = createSummaryApp(domElements);
+    await app.fetchAndRender();
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/summary?year=2024&month=06');
-    expect(chartFactory).toHaveBeenCalledTimes(1);
-    expect(document.getElementById('summary-total').textContent).toMatch(/3[.,]000/);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    const urls = fetchMock.mock.calls.map(call => call[0]);
+    expect(urls).toEqual([
+      '/api/summary?year=2024&month=01',
+      '/api/summary?year=2024&month=02',
+      '/api/summary?year=2024&month=03',
+      '/api/summary?year=2024&month=04',
+      '/api/summary?year=2024&month=05',
+      '/api/summary?year=2024&month=06'
+    ]);
+    expect(chartFactory).toHaveBeenCalledTimes(5);
+    expect(domElements.categoryChartsDiv.querySelectorAll('canvas').length).toBe(4);
   });
 });

--- a/public/summary.test.js
+++ b/public/summary.test.js
@@ -53,5 +53,6 @@ describe('summary.js', () => {
     ]);
     expect(chartFactory).toHaveBeenCalledTimes(5);
     expect(domElements.categoryChartsDiv.querySelectorAll('canvas').length).toBe(4);
+    expect(domElements.categoryChartsDiv.querySelectorAll('.chart-container').length).toBe(4);
   });
 });

--- a/public/summary.test.js
+++ b/public/summary.test.js
@@ -12,7 +12,7 @@ function buildHTML() {
 describe('summary.js', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-06-15T00:00:00Z'));
+    vi.setSystemTime(new Date('2024-08-15T00:00:00Z'));
   });
 
   it('fetches last 6 months and renders charts', async () => {
@@ -44,12 +44,12 @@ describe('summary.js', () => {
     expect(fetchMock).toHaveBeenCalledTimes(6);
     const urls = fetchMock.mock.calls.map(call => call[0]);
     expect(urls).toEqual([
-      '/api/summary?year=2024&month=01',
       '/api/summary?year=2024&month=02',
       '/api/summary?year=2024&month=03',
       '/api/summary?year=2024&month=04',
       '/api/summary?year=2024&month=05',
-      '/api/summary?year=2024&month=06'
+      '/api/summary?year=2024&month=06',
+      '/api/summary?year=2024&month=07'
     ]);
     expect(chartFactory).toHaveBeenCalledTimes(5);
     expect(domElements.categoryChartsDiv.querySelectorAll('canvas').length).toBe(4);

--- a/public/summary/index.html
+++ b/public/summary/index.html
@@ -23,24 +23,21 @@
     <div class="container mt-5">
         <h1 class="mb-4 text-center">Summary</h1>
         <div class="d-flex justify-content-center mb-4">
-            <input type="month" id="month-picker" class="form-control" style="max-width:200px;">
-        </div>
-        <div id="summary-total" class="text-center mb-4"></div>
-        <div class="d-flex justify-content-center">
             <div class="chart-container" style="max-width:600px;width:100%;height:400px;">
-                <canvas id="summary-chart"></canvas>
+                <canvas id="total-chart"></canvas>
             </div>
         </div>
+        <div id="category-charts" class="row gy-4"></div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="module">
         import { createSummaryApp } from '/summary.js';
-        createSummaryApp({
-            monthPicker: document.getElementById('month-picker'),
-            chartCanvas: document.getElementById('summary-chart'),
-            totalDiv: document.getElementById('summary-total')
+        const app = createSummaryApp({
+            categoryChartsDiv: document.getElementById('category-charts'),
+            totalCanvas: document.getElementById('total-chart')
         });
+        app.fetchAndRender();
     </script>
 </body>
 </html>

--- a/public/summary/index.html
+++ b/public/summary/index.html
@@ -23,7 +23,7 @@
     <div class="container mt-5">
         <h1 class="mb-4 text-center">Summary</h1>
         <div class="d-flex justify-content-center mb-4">
-            <div class="chart-container" style="max-width:600px;width:100%;height:400px;">
+            <div class="chart-container" style="max-width:600px;width:100%;height:300px;">
                 <canvas id="total-chart"></canvas>
             </div>
         </div>

--- a/ui.test.js
+++ b/ui.test.js
@@ -48,8 +48,8 @@ describe('Expense Tracker UI', () => {
     await loadPage('summary');
     const heading = await driver.findElement(By.css('h1')).getText();
     expect(heading.toLowerCase()).toContain('summary');
-    await driver.findElement(By.id('month-picker'));
-    await driver.findElement(By.id('summary-chart'));
+    await driver.findElement(By.id('total-chart'));
+    await driver.findElement(By.id('category-charts'));
   });
 
   it('renders insights placeholder', async () => {


### PR DESCRIPTION
## Summary
- Render six months of spending trends per daily category and overall totals on the summary page.
- Replace month selector with automatically generated line charts.
- Update tests and UI checks for new summary layout.

## Testing
- `npm test` *(fails: Unable to obtain browser driver)*


------
https://chatgpt.com/codex/tasks/task_e_689d9eff6680832aaf54cd4a3cbe22d1