### PR TITLE
ci(gemini): pin model to gemini-2.5-flash to cut cost

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -115,6 +115,7 @@ jobs:
         if: |-
           ${{ github.event_name == 'issue_comment' }}
         env:
+          GEMINI_MODEL: gemini-2.5-flash
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           COMMENT_BODY: '${{ github.event.comment.body }}'
           PR_NUMBER: '${{ github.event.issue.number }}'


### PR DESCRIPTION
Set GEMINI_MODEL in the workflow so PR reviews run on 2.5-flash. Lower cost with similar quality. No code behavior change expected.